### PR TITLE
updates HTTParty to 0.14.0 for Rails 5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.0
-before_install: gem install bundler -v 1.11.2
+  - 2.3.3
+  - 2.4.0
+before_install: bin/setup
+script:
+  - rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in ionic_push.gemspec
 gemspec
 
-gem 'httparty'
+gem 'httparty', ">= 0.14.0"

--- a/ionic_push.gemspec
+++ b/ionic_push.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "httparty", "~> 0.13.7"
+  spec.add_runtime_dependency "httparty", ">= 0.14.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 2.0", ">= 2.0.0"
   spec.add_development_dependency "pry", "~> 0.10.3"
   spec.add_development_dependency "rubocop", "~> 0.39.0"
+  
+  spec.required_ruby_version = '~> 2.0'
 end

--- a/lib/ionic_push/version.rb
+++ b/lib/ionic_push/version.rb
@@ -1,3 +1,3 @@
 module IonicPush
-  VERSION = '0.2.3'.freeze
+  VERSION = '0.2.4'.freeze
 end


### PR DESCRIPTION
This drops support for Ruby 1.9.3.
New ionic_push Gem-Version: 0.2.4

HTTParty < 0.14 used the JSON-gem < 2.0. This was not compatible with Rails 5 using the JSON-gem in a version >= 2.x.
The new HTTParty uses multi_xml instead, so we do not have JSON-gem conflict; however, it dropped support for Ruby 1.9.3. I added a line in the gem-spec regarding the ruby version.

Tests are green. 
This also adds a .travis.yml [that runs the tests](https://travis-ci.org/MichaelWhi/ionic_push). (can be activated for your repo at https://travis-ci.org)